### PR TITLE
Run as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM hashicorp/terraform:0.11.11
+FROM hashicorp/terraform:0.11.13
 MAINTAINER "Contino APAC <delivery.au@contino.io>"
 
 RUN apk add --update --no-cache make bash python3 && \
     pip3 install --upgrade pip && \
-        pip3 install google google-api-python-client google-auth && \
-        pip3 install awscli
+    pip3 install google google-api-python-client google-auth && \
+    pip3 install awscli
 
-VOLUME [ "/opt/app" ]
+# download and install gosu
+COPY --from=gosu/assets /opt/gosu /opt/gosu
+RUN /opt/gosu/gosu.install.sh && rm -fr /opt/gosu
+
+# use custom entrypoint to always use hosts user UID and GID
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# set default working directory to try and determine UID and GID
+VOLUME ["/opt/app"]
 WORKDIR /opt/app
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["--version"]

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,22 @@
-TERRAFORM_VERSION=0.11.11
+.SILENT:
+TERRAFORM_VERSION = 0.11.13
 IMAGE_NAME ?= contino/terraform:$(TERRAFORM_VERSION)
 TAG = $(TERRAFORM_VERSION)
 
+.PHONY: build
 build:
 	docker build -t $(IMAGE_NAME) .
 
+.PHONY: test
 test:
-	@docker run --rm -it --entrypoint="terraform" $(IMAGE_NAME) --version
-	@docker run --rm -it --entrypoint="aws" $(IMAGE_NAME) --version
+	docker run --rm -it --entrypoint="terraform" $(IMAGE_NAME) --version
+	docker run --rm -it --entrypoint="aws" $(IMAGE_NAME) --version
 
+.PHONY: shell
 shell:
-	docker run --rm -it -v ~/.aws:/root/.aws -v $(shell pwd):/opt/app $(IMAGE_NAME) bash
+	docker run --rm -it --entrypoint="bash" -v ~/.aws:/root/.aws -v $(shell pwd):/opt/app $(IMAGE_NAME)
 
+.PHONY: gitTag
 gitTag:
 	-git tag -d $(TAG)
 	-git push origin :refs/tags/$(TAG)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Containerised Terraform CLI with Pythyon3, GCP, AWS sdks and GOSU installed.
 
 ## Usage
 The below 2 examples are using the `terraform` user inside the container.
-This is explained below in [Configuration](##configuration).
+This is explained below in [Configuration](#configuration).
 
 ### Docker
 Run as a command:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# set uid and gid with same permissions as mount point
+USER_ID=${TERRAFORM_UID:-$(stat -c %u "$(pwd)")}
+GROUP_ID=${TERRAFORM_GID:-$(stat -c %g "$(pwd)")}
+USER_NAME=${TERRAFORM_USER:-terraform}
+GROUP_NAME=${TERRAFORM_GROUP:-terraform}
+
+# add our custom group and user
+addgroup -S -g "${GROUP_ID}" "${GROUP_NAME}"
+adduser -S -s /bin/bash -u "${USER_ID}" -G "${GROUP_NAME}" "${USER_NAME}"
+
+# change to new home directory
+export HOME=/home/${USER_NAME}
+
+# run commands with new UID and GID
+exec gosu "${USER_NAME}" terraform "$@"


### PR DESCRIPTION
Fixes https://github.com/contino/docker-terraform/issues/3

## Changes
The idea of this change is to intercept the initial terraform command and use `gosu` to run as our custom user. The entrypoint will try and determine the mountpoints UID and GID automatically and thus not having any of the files owned by root or a user that doesn't exist on your hosts machine.

Some extra variables will be made available in case this doesn't work as expected or some edge cases are found:
- Attempt at using gosu to run container as non-root user
- Custom options to pass in custom UID and GID to fix these with particular values
	- TERRAFORM_UID
	- TERRAFORM_GID
- Custom optional variables to pass in user and group names to fix these with particular values
	- TERRAFORM_USER
	- TERRAFORM_GROUP

## Caveats
- This obviously will not be invoked when changing the entrypoint to bash for example

## README
Heavy update to the README to try and create a standard and easy to read and digest for a new developer