### PR TITLE
Only create a new user if docker remaps for root havent been configured

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,12 +7,18 @@ GROUP_ID=${TERRAFORM_GID:-$(stat -c %g "$(pwd)")}
 USER_NAME=${TERRAFORM_USER:-terraform}
 GROUP_NAME=${TERRAFORM_GROUP:-terraform}
 
-# add our custom group and user
-addgroup -S -g "${GROUP_ID}" "${GROUP_NAME}"
-adduser -S -s /bin/bash -u "${USER_ID}" -G "${GROUP_NAME}" "${USER_NAME}"
+# only create new user if we haven't docker remapped
+# https://docs.docker.com/engine/security/userns-remap/
+if [ "${USER_ID}" == "0" ]; then
+  terraform "$@"
+else
+  # add our custom group and user
+  addgroup -S -g "${GROUP_ID}" "${GROUP_NAME}"
+  adduser -S -s /bin/bash -u "${USER_ID}" -G "${GROUP_NAME}" "${USER_NAME}"
 
-# change to new home directory
-export HOME=/home/${USER_NAME}
+  # change to new home directory
+  export HOME=/home/${USER_NAME}
 
-# run commands with new UID and GID
-exec gosu "${USER_NAME}" terraform "$@"
+  # run commands with new UID and GID
+  exec gosu "${USER_NAME}" terraform "$@"
+fi


### PR DESCRIPTION
- Need to get backwards compatibility with hosts that have a remap with "root" ownership